### PR TITLE
Feature/add typesafety

### DIFF
--- a/src/robot_smach_states/human_interaction/human_interaction.py
+++ b/src/robot_smach_states/human_interaction/human_interaction.py
@@ -35,6 +35,13 @@ class Say(State):
     >>> robot.speech.speak.assert_any_call('b', 'us', 'kyle', 'default', 'excited', True)
     >>> robot.speech.speak.assert_any_call('c', 'us', 'kyle', 'default', 'excited', True)"""
     def __init__(self, robot, sentence=None, language="us", personality="kyle", voice="default", mood="excited", block=True):
+        assert((hasattr(sentence, "resolve_type") and sentence.resolve_type in (str, list)) or type(sentence) in (str, list)) 
+        assert((hasattr(language, "resolve_type") and language.resolve_type == str) or type(language) == str) 
+        assert((hasattr(personality, "resolve_type") and personality.resolve_type == str) or type(personality) == str) 
+        assert((hasattr(voice, "resolve_type") and voice.resolve_type == str) or type(voice) == str) 
+        assert((hasattr(mood, "resolve_type") and mood.resolve_type == str) or type(mood) == str) 
+        assert((hasattr(block, "resolve_type") and block.resolve_type == bool) or type(block) == bool) 
+        
         State.__init__(self, locals(), outcomes=["spoken"])
 
     def run(self, robot, sentence, language, personality, voice, mood, block):

--- a/src/robot_smach_states/human_interaction/human_interaction.py
+++ b/src/robot_smach_states/human_interaction/human_interaction.py
@@ -6,7 +6,7 @@ import random
 
 from robot_smach_states.state import State
 
-from robot_smach_states.util.designators import Designator, DesignatorResolvementError, EdEntityDesignator
+from robot_smach_states.util.designators import Designator, DesignatorResolvementError, EdEntityDesignator, check_type
 from robot_smach_states.utility import WaitForDesignator
 import robot_skills.util.msg_constructors as gm
 
@@ -35,13 +35,14 @@ class Say(State):
     >>> robot.speech.speak.assert_any_call('b', 'us', 'kyle', 'default', 'excited', True)
     >>> robot.speech.speak.assert_any_call('c', 'us', 'kyle', 'default', 'excited', True)"""
     def __init__(self, robot, sentence=None, language="us", personality="kyle", voice="default", mood="excited", block=True):
-        assert((hasattr(sentence, "resolve_type") and sentence.resolve_type in (str, list)) or type(sentence) in (str, list)) 
-        assert((hasattr(language, "resolve_type") and language.resolve_type == str) or type(language) == str) 
-        assert((hasattr(personality, "resolve_type") and personality.resolve_type == str) or type(personality) == str) 
-        assert((hasattr(voice, "resolve_type") and voice.resolve_type == str) or type(voice) == str) 
-        assert((hasattr(mood, "resolve_type") and mood.resolve_type == str) or type(mood) == str) 
-        assert((hasattr(block, "resolve_type") and block.resolve_type == bool) or type(block) == bool) 
-        
+        check_type(sentence, str, list)
+        check_type(sentence, str, list)
+        check_type(language, str)
+        check_type(personality, str)
+        check_type(voice, str)
+        check_type(mood, str)
+        check_type(block, bool)
+
         State.__init__(self, locals(), outcomes=["spoken"])
 
     def run(self, robot, sentence, language, personality, voice, mood, block):
@@ -107,9 +108,9 @@ class HearOptionsExtra(smach.State):
     >>> state = HearOptionsExtra(mockbot, spec, choices, answer)
     >>> outcome = state.execute()
     """
-    def __init__(self, robot, spec_designator, 
-                        choices_designator, 
-                        speech_result_designator, 
+    def __init__(self, robot, spec_designator,
+                        choices_designator,
+                        speech_result_designator,
                         time_out=rospy.Duration(10)):
         smach.State.__init__(self, outcomes=["heard", "no_result"])
 
@@ -149,12 +150,12 @@ class AskContinue(smach.StateMachine):
 
         with self:
             smach.StateMachine.add('SAY',
-                                    Say(self.robot, 
-                                        random.choice(["I will continue my task if you say continue.","Please say continue so that I can continue my task.","I will wait until you say continue."])), 
+                                    Say(self.robot,
+                                        random.choice(["I will continue my task if you say continue.","Please say continue so that I can continue my task.","I will wait until you say continue."])),
                                     transitions={'spoken':'HEAR'})
-            
-            smach.StateMachine.add('HEAR', 
-                                    Hear(self.robot, 'continue', self.timeout), 
+
+            smach.StateMachine.add('HEAR',
+                                    Hear(self.robot, 'continue', self.timeout),
                                     transitions={'heard':'continue','not_heard':'no_response'})
 
 ##########################################################################################################################################

--- a/src/robot_smach_states/manipulation/grab.py
+++ b/src/robot_smach_states/manipulation/grab.py
@@ -9,14 +9,20 @@ import tf
 
 from robot_smach_states.state import State
 
-# from cb_planner_msgs_srvs.srv import *
-# from cb_planner_msgs_srvs.msg import *
+import ed.msg
+from robot_skills.arms import Arm
 
 from robot_smach_states.navigation import NavigateToGrasp
 
 
 class PickUp(State):
     def __init__(self, robot, arm, grab_entity):
+        #Check that the entity_designator resolves to an Entity or is an entity
+        assert(grab_entity.resolve_type == ed.msg.EntityInfo or type(grab_entity) == ed.msg.EntityInfo)
+        
+        #Check that the arm is a designator that resolves to an Arm or is an Arm
+        assert(arm.resolve_type == Arm or type(arm) == Arm) 
+
         State.__init__(self, locals(), outcomes=['succeeded', 'failed'])
 
     def run(self, robot, arm, grab_entity):
@@ -109,6 +115,11 @@ class PickUp(State):
 class Grab(smach.StateMachine):
     def __init__(self, robot, item, arm):
         smach.StateMachine.__init__(self, outcomes=['done', 'failed'])
+
+        #Check types or designator resolve types
+        assert(item.resolve_type == ed.msg.EntityInfo or type(item) == ed.msg.EntityInfo)
+        assert(arm.resolve_type == Arm or type(arm) == Arm) 
+
 
         with self:
             smach.StateMachine.add('NAVIGATE_TO_GRAB', NavigateToGrasp(robot, item, arm),

--- a/src/robot_smach_states/manipulation/grab.py
+++ b/src/robot_smach_states/manipulation/grab.py
@@ -9,6 +9,7 @@ import tf
 
 from robot_smach_states.state import State
 
+from robot_smach_states.util.designators import check_type
 import ed.msg
 from robot_skills.arms import Arm
 
@@ -18,10 +19,10 @@ from robot_smach_states.navigation import NavigateToGrasp
 class PickUp(State):
     def __init__(self, robot, arm, grab_entity):
         #Check that the entity_designator resolves to an Entity or is an entity
-        assert(grab_entity.resolve_type == ed.msg.EntityInfo or type(grab_entity) == ed.msg.EntityInfo)
-        
+        check_type(grab_entity, ed.msg.EntityInfo)
+
         #Check that the arm is a designator that resolves to an Arm or is an Arm
-        assert(arm.resolve_type == Arm or type(arm) == Arm) 
+        check_type(arm, Arm)
 
         State.__init__(self, locals(), outcomes=['succeeded', 'failed'])
 
@@ -117,8 +118,8 @@ class Grab(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=['done', 'failed'])
 
         #Check types or designator resolve types
-        assert(item.resolve_type == ed.msg.EntityInfo or type(item) == ed.msg.EntityInfo)
-        assert(arm.resolve_type == Arm or type(arm) == Arm) 
+        check_type(item, ed.msg.EntityInfo)
+        check_type(arm, Arm)
 
 
         with self:

--- a/src/robot_smach_states/manipulation/manipulation.py
+++ b/src/robot_smach_states/manipulation/manipulation.py
@@ -12,6 +12,7 @@ import robot_skills.util.msg_constructors as msgs
 from robot_skills.arms import ArmState
 from robot_smach_states.util.designators import PointStampedOfEntityDesignator, DesignatorResolvementError, LockingDesignator
 
+from robot_smach_states.util.designators import check_type
 from robot_skills.arms import Arm
 
 
@@ -21,7 +22,7 @@ from robot_skills.arms import Arm
 # handover_to_human: -0.2, -0.7, 0.2, 2.0, 0, 0.5, 0.3
 # prepare_grasp: -0.2, -0.044, 0.69, 1.4, -0.13, 0.38, 0.42
 # retract: -0.1, 0.0, 0.0, 0.0, 0.0, 0.0
-# 
+#
 # TODO: trajectories to move to robot_description:
 #
 #
@@ -35,7 +36,7 @@ class ArmToJointConfig(smach.State):
         smach.State.__init__(self, outcomes=['succeeded','failed'])
 
         self.robot = robot
-        assert(arm_designator.resolve_type == Arm)
+        check_type(arm_designator, Arm)
         self.arm_designator = arm_designator
         self.configuration = configuration
 
@@ -50,7 +51,7 @@ class ArmToJointTrajectory(smach.State):
         smach.State.__init__(self, outcomes=['succeeded','failed'])
 
         self.robot = robot
-        assert(arm_designator.resolve_type == Arm)
+        check_type(arm_designator, Arm)
         self.arm_designator = arm_designator
         self.trajectory = trajectory
 
@@ -66,7 +67,7 @@ class PrepareGraspSafe(smach.State):
         smach.State.__init__(self, outcomes=['succeeded','failed'])
 
         self.robot = robot
-        assert(arm_designator.resolve_type == Arm)
+        check_type(arm_designator, Arm)
         self.arm_designator = arm_designator
         self.grab_entity_designator = grab_entity_designator
 
@@ -109,8 +110,8 @@ class GrabMachine(smach.StateMachine):
         """@param grab_entity_designator resolves to an entity to grab.
             Some child states require a (designator of) the PointStamped of that entity. PointStampedOfEntityDesignator does this conversion"""
         smach.StateMachine.__init__(self, outcomes=['succeeded','failed'])
-        
-        assert(arm_designator.resolve_type == Arm)
+
+        check_type(arm_designator, Arm)
 
         # check check input and output keys
         with self:
@@ -122,8 +123,8 @@ class GrabMachine(smach.StateMachine):
                         transitions={'succeeded'    :   'PREPARE_ORIENTATION',
                                      'failed'       :   'PREPARE_ORIENTATION'})
 
-            smach.StateMachine.add('PRE_GRASP', ArmToQueryPoint(robot, arm_designator, 
-                                    PointStampedOfEntityDesignator(grab_entity_designator), 
+            smach.StateMachine.add('PRE_GRASP', ArmToQueryPoint(robot, arm_designator,
+                                    PointStampedOfEntityDesignator(grab_entity_designator),
                                     time_out=20, pre_grasp=True, first_joint_pos_only=True),
                         transitions={'succeeded'    :   'GRAB',
                                      'failed'       :   'CLOSE_GRIPPER_UPON_FAIL'})
@@ -157,7 +158,7 @@ class GrabWithVisualServoing(smach.State):
 
         self.robot = robot
 
-        assert(arm_designator.resolve_type == Arm)
+        check_type(arm_designator, Arm)
         self.arm_designator = arm_designator
         self.grab_point_designator = grab_point_designator
 
@@ -178,7 +179,7 @@ class GrabWithVisualServoing(smach.State):
             rospy.loginfo("Could not resolve grab_point_designator {0}: {1}".format(self.grab_point_designator, e))
             return "target_lost"
 
-        # Keep looking at end-effector for ar marker detection 
+        # Keep looking at end-effector for ar marker detection
         self.robot.head.look_at_goal(msgs.PointStamped(0,0,0,frame_id=end_effector_frame_id))
         rospy.loginfo("[robot_smach_states:grasp] Target position: {0}".format(target_position))
 
@@ -187,13 +188,13 @@ class GrabWithVisualServoing(smach.State):
 
         target_position_delta = geometry_msgs.msg.Point()
 
-        # First check to see if visual servoing is possible 
+        # First check to see if visual servoing is possible
         self.robot.perception.toggle(['ar_pose'])
 
-        # Transform point(0,0,0) in ar marker frame to grippoint frame 
+        # Transform point(0,0,0) in ar marker frame to grippoint frame
         ar_point = msgs.PointStamped(0, 0, 0, frame_id = ar_frame_id, stamp = rospy.Time())
 
-        # Check several times if transform is available 
+        # Check several times if transform is available
         cntr = 0
         ar_marker_available = False
         while (cntr < 5 and not ar_marker_available):
@@ -205,7 +206,7 @@ class GrabWithVisualServoing(smach.State):
                 cntr += 1
                 rospy.sleep(0.2)
 
-        # If transform is not available, try again, but use head movement as well 
+        # If transform is not available, try again, but use head movement as well
         if not ar_marker_available:
             arm.send_delta_goal(0.05,0.0,0.0,0.0,0.0,0.0, timeout=5.0, frame_id=end_effector_frame_id, pre_grasp = False)
             self.robot.speech.speak("Let me have a closer look", block=False)
@@ -213,11 +214,11 @@ class GrabWithVisualServoing(smach.State):
         ar_point_grippoint = transformations.tf_transform(ar_point, ar_frame_id, end_effector_frame_id, tf_listener=self.robot.tf_listener)
         rospy.loginfo("AR marker in end-effector frame = {0}".format(ar_point_grippoint))
 
-        # Transform target position to grippoint frame 
+        # Transform target position to grippoint frame
         target_position_grippoint = transformations.tf_transform(target_position, "/map", end_effector_frame_id, tf_listener=self.robot.tf_listener)
         rospy.loginfo("Target position in end-effector frame = {0}".format(target_position_grippoint))
 
-        # Compute difference = delta (only when both transformations have succeeded) and correct for offset ar_marker and grippoint 
+        # Compute difference = delta (only when both transformations have succeeded) and correct for offset ar_marker and grippoint
         if not (ar_point_grippoint == None or target_position_grippoint == None):
             target_position_delta = msgs.Point(target_position_grippoint.x - ar_point_grippoint.x + arm.markerToGrippointOffset.x,
                 target_position_grippoint.y - ar_point_grippoint.y + arm.markerToGrippointOffset.y,
@@ -228,7 +229,7 @@ class GrabWithVisualServoing(smach.State):
             ar_marker_available = False
         rospy.logwarn("ar_marker_available (2) = {0}".format(ar_marker_available))
 
-        # Sanity check 
+        # Sanity check
         if ar_marker_available:
             #rospy.loginfo("Delta target = {0}".format(target_position_delta))
             if (target_position_delta.x < 0 or target_position_delta.x > 0.6 or target_position_delta.y < -0.3 or target_position_delta.y > 0.3 or target_position_delta.z < -0.3 or target_position_delta.z > 0.3):
@@ -237,10 +238,10 @@ class GrabWithVisualServoing(smach.State):
                 ar_marker_available = False
         rospy.logwarn("ar_marker_available (3) = {0}".format(ar_marker_available))
 
-        # Switch off ar marker detection 
+        # Switch off ar marker detection
         self.robot.perception.toggle([])
 
-        # Original, pregrasp is performed by the compute_pre_grasp node 
+        # Original, pregrasp is performed by the compute_pre_grasp node
         if not ar_marker_available:
             self.robot.speech.speak("Let's see", block=False)
             if arm.send_goal(target_position_bl.x, target_position_bl.y, target_position_bl.z, 0, 0, 0, 120, pre_grasp = True):
@@ -267,7 +268,7 @@ class HandoverFromHuman(smach.StateMachine):
     def __init__(self, robot, arm_designator):
         smach.StateMachine.__init__(self, outcomes=['succeeded','failed'])
 
-        assert(arm_designator.resolve_type == Arm)
+        check_type(arm_designator, Arm)
 
         with self:
             smach.StateMachine.add("POSE", ArmToJointConfig(robot, arm_designator, "carrying_pose"),
@@ -290,8 +291,8 @@ class HandoverToHuman(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=['succeeded','failed'])
 
         #A designator can resolve to a different item every time its resolved. We don't want that here, so lock
-        assert(arm_designator.resolve_type == Arm)
-        locked_arm = LockingDesignator(arm_designator) 
+        check_type(arm_designator, Arm)
+        locked_arm = LockingDesignator(arm_designator)
 
         with self:
             smach.StateMachine.add("LOCK_ARM",
@@ -339,7 +340,7 @@ class SetGripper(smach.State):
     def __init__(self, robot, arm_designator, gripperstate='open', drop_from_frame=None, grab_entity_designator=None, timeout=10):
         smach.State.__init__(self, outcomes=['succeeded','failed'])
 
-        assert(arm_designator.resolve_type == Arm)
+        check_type(arm_designator, Arm)
         self.arm_designator = arm_designator
         self.robot = robot
         self.gripperstate = gripperstate
@@ -349,7 +350,7 @@ class SetGripper(smach.State):
     def execute(self, userdata):
         arm = self.arm_designator.resolve()
 
-        # If needs attaching to gripper, the grab_entity_designator is used 
+        # If needs attaching to gripper, the grab_entity_designator is used
         if self.grab_entity_designator:
             try:
                 entity = self.grab_entity_designator.resolve()
@@ -464,8 +465,8 @@ class TorsoToUserPos(smach.State):
 class PointMachine(smach.StateMachine):
     def __init__(self, robot, arm_designator, grab_entity_designator):
         smach.StateMachine.__init__(self, outcomes=['succeeded','failed'])
-        
-        assert(arm_designator.resolve_type == Arm)
+
+        check_type(arm_designator, Arm)
         self.arm_designator = arm_designator
         self.robot = robot
         self.grab_entity_designator = grab_entity_designator
@@ -488,7 +489,7 @@ class PointMachine(smach.StateMachine):
                                     Say(robot, "I hope this is the object you were looking for."),
                         transitions={ 'spoken':'RETRACT' })
 
-            smach.StateMachine.add('RETRACT', 
+            smach.StateMachine.add('RETRACT',
                                     ArmToJointConfig(robot, arm_designator, 'retract'),
                         transitions={'succeeded':'RESET_ARM_SUCCEEDED','failed':'RESET_ARM_SUCCEEDED'})
 
@@ -506,7 +507,7 @@ class Point_at_object(smach.State):
     def __init__(self, robot, arm_designator, point_entity_designator):
         smach.State.__init__(self, outcomes=['point_succeeded','point_failed','target_lost'])
 
-        assert(arm_designator.resolve_type == Arm)
+        check_type(arm_designator, Arm)
         self.arm_designator = arm_designator
         self.robot = robot
         self.point_entity_designator = point_entity_designator
@@ -524,14 +525,14 @@ class Point_at_object(smach.State):
         target_position = msgs.PointStamped(entity.pose, frame_id = "/map", stamp = rospy.Time())
         rospy.loginfo("[robot_smach_states:Point_at_object] Target position: {0}".format(target_position))
 
-        # Keep looking at end-effector for ar marker detection 
+        # Keep looking at end-effector for ar marker detection
         self.robot.head.look_at_point(msgs.PointStamped(0,0,0,frame_id=end_effector_frame_id))
 
-        # Transform to base link 
+        # Transform to base link
         target_position_bl = transformations.tf_transform(target_position, "/map","/amigo/base_link", tf_listener=self.robot.tf_listener)
         rospy.loginfo("[robot_smach_states] Target position in base link: {0}".format(target_position_bl))
 
-        # Send goal 
+        # Send goal
         if arm.send_goal(target_position_bl.x-0.1, target_position_bl.y, target_position_bl.z, 0, 0, 0, 120, pre_grasp = True):
             rospy.loginfo("arm at object")
         else:

--- a/src/robot_smach_states/manipulation/manipulation.py
+++ b/src/robot_smach_states/manipulation/manipulation.py
@@ -12,6 +12,8 @@ import robot_skills.util.msg_constructors as msgs
 from robot_skills.arms import ArmState
 from robot_smach_states.util.designators import PointStampedOfEntityDesignator, DesignatorResolvementError, LockingDesignator
 
+from robot_skills.arms import Arm
+
 
 # TODO: poses to move to robot_description:
 # carrying_pose: 0.18, y_home, 0.75, 0, 0, 0, 60
@@ -33,6 +35,7 @@ class ArmToJointConfig(smach.State):
         smach.State.__init__(self, outcomes=['succeeded','failed'])
 
         self.robot = robot
+        assert(arm_designator.resolve_type == Arm)
         self.arm_designator = arm_designator
         self.configuration = configuration
 
@@ -47,6 +50,7 @@ class ArmToJointTrajectory(smach.State):
         smach.State.__init__(self, outcomes=['succeeded','failed'])
 
         self.robot = robot
+        assert(arm_designator.resolve_type == Arm)
         self.arm_designator = arm_designator
         self.trajectory = trajectory
 
@@ -62,6 +66,7 @@ class PrepareGraspSafe(smach.State):
         smach.State.__init__(self, outcomes=['succeeded','failed'])
 
         self.robot = robot
+        assert(arm_designator.resolve_type == Arm)
         self.arm_designator = arm_designator
         self.grab_entity_designator = grab_entity_designator
 
@@ -104,6 +109,8 @@ class GrabMachine(smach.StateMachine):
         """@param grab_entity_designator resolves to an entity to grab.
             Some child states require a (designator of) the PointStamped of that entity. PointStampedOfEntityDesignator does this conversion"""
         smach.StateMachine.__init__(self, outcomes=['succeeded','failed'])
+        
+        assert(arm_designator.resolve_type == Arm)
 
         # check check input and output keys
         with self:
@@ -149,6 +156,8 @@ class GrabWithVisualServoing(smach.State):
         smach.State.__init__(self, outcomes=['succeeded','failed','target_lost'])
 
         self.robot = robot
+
+        assert(arm_designator.resolve_type == Arm)
         self.arm_designator = arm_designator
         self.grab_point_designator = grab_point_designator
 
@@ -258,6 +267,8 @@ class HandoverFromHuman(smach.StateMachine):
     def __init__(self, robot, arm_designator):
         smach.StateMachine.__init__(self, outcomes=['succeeded','failed'])
 
+        assert(arm_designator.resolve_type == Arm)
+
         with self:
             smach.StateMachine.add("POSE", ArmToJointConfig(robot, arm_designator, "carrying_pose"),
                             transitions={'succeeded':'OPEN_BEFORE_INSERT','failed':'OPEN_BEFORE_INSERT'})
@@ -279,6 +290,7 @@ class HandoverToHuman(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=['succeeded','failed'])
 
         #A designator can resolve to a different item every time its resolved. We don't want that here, so lock
+        assert(arm_designator.resolve_type == Arm)
         locked_arm = LockingDesignator(arm_designator) 
 
         with self:
@@ -326,6 +338,8 @@ class HandoverToHuman(smach.StateMachine):
 class SetGripper(smach.State):
     def __init__(self, robot, arm_designator, gripperstate='open', drop_from_frame=None, grab_entity_designator=None, timeout=10):
         smach.State.__init__(self, outcomes=['succeeded','failed'])
+
+        assert(arm_designator.resolve_type == Arm)
         self.arm_designator = arm_designator
         self.robot = robot
         self.gripperstate = gripperstate
@@ -450,6 +464,8 @@ class TorsoToUserPos(smach.State):
 class PointMachine(smach.StateMachine):
     def __init__(self, robot, arm_designator, grab_entity_designator):
         smach.StateMachine.__init__(self, outcomes=['succeeded','failed'])
+        
+        assert(arm_designator.resolve_type == Arm)
         self.arm_designator = arm_designator
         self.robot = robot
         self.grab_entity_designator = grab_entity_designator
@@ -490,6 +506,7 @@ class Point_at_object(smach.State):
     def __init__(self, robot, arm_designator, point_entity_designator):
         smach.State.__init__(self, outcomes=['point_succeeded','point_failed','target_lost'])
 
+        assert(arm_designator.resolve_type == Arm)
         self.arm_designator = arm_designator
         self.robot = robot
         self.point_entity_designator = point_entity_designator

--- a/src/robot_smach_states/manipulation/place.py
+++ b/src/robot_smach_states/manipulation/place.py
@@ -7,6 +7,7 @@ from robot_smach_states.navigation import NavigateToPlace
 
 from robot_smach_states.state import State
 
+from robot_smach_states.util.designators import check_type
 import ed.msg
 from robot_skills.arms import Arm
 from geometry_msgs.msg import PoseStamped
@@ -17,9 +18,10 @@ class Put(State):
 
     def __init__(self, robot, item_to_place, placement_pose, arm):
         #Check types or designator resolve types
-        assert(item_to_place.resolve_type == ed.msg.EntityInfo or type(item_to_place) == ed.msg.EntityInfo)
-        assert(placement_pose.resolve_type == PoseStamped or type(placement_pose) == PoseStamped)
-        assert(arm.resolve_type == Arm or type(arm) == Arm) 
+
+        check_type(item_to_place, ed.msg.EntityInfo)
+        check_type(placement_pose, PoseStamped)
+        check_type(arm, Arm)
 
         State.__init__(self, locals(), outcomes=['succeeded', 'failed'])
 
@@ -78,7 +80,7 @@ class Put(State):
         arm.send_gripper_goal('close')
 
         arm.reset()
-        
+
         return 'succeeded'
 
 class Place(smach.StateMachine):
@@ -89,7 +91,7 @@ class Place(smach.StateMachine):
         #Check types or designator resolve types
         assert(item_to_place.resolve_type == ed.msg.EntityInfo or type(item_to_place) == ed.msg.EntityInfo)
         assert(place_pose.resolve_type == PoseStamped or type(place_pose) == PoseStamped)
-        assert(arm.resolve_type == Arm or type(arm) == Arm) 
+        assert(arm.resolve_type == Arm or type(arm) == Arm)
 
         with self:
             smach.StateMachine.add('NAVIGATE_TO_PLACE', NavigateToPlace(robot, place_pose, arm),  # TODO: Navigate to place

--- a/src/robot_smach_states/manipulation/place.py
+++ b/src/robot_smach_states/manipulation/place.py
@@ -7,11 +7,20 @@ from robot_smach_states.navigation import NavigateToPlace
 
 from robot_smach_states.state import State
 
+import ed.msg
+from robot_skills.arms import Arm
+from geometry_msgs.msg import PoseStamped
+
 # ----------------------------------------------------------------------------------------------------
 
 class Put(State):
 
     def __init__(self, robot, item_to_place, placement_pose, arm):
+        #Check types or designator resolve types
+        assert(item_to_place.resolve_type == ed.msg.EntityInfo or type(item_to_place) == ed.msg.EntityInfo)
+        assert(placement_pose.resolve_type == PoseStamped or type(placement_pose) == PoseStamped)
+        assert(arm.resolve_type == Arm or type(arm) == Arm) 
+
         State.__init__(self, locals(), outcomes=['succeeded', 'failed'])
 
     def run(self, robot, item_to_place, placement_pose, arm):
@@ -76,6 +85,11 @@ class Place(smach.StateMachine):
 
     def __init__(self, robot, item_to_place, place_pose, arm):
         smach.StateMachine.__init__(self, outcomes=['done', 'failed'])
+
+        #Check types or designator resolve types
+        assert(item_to_place.resolve_type == ed.msg.EntityInfo or type(item_to_place) == ed.msg.EntityInfo)
+        assert(place_pose.resolve_type == PoseStamped or type(place_pose) == PoseStamped)
+        assert(arm.resolve_type == Arm or type(arm) == Arm) 
 
         with self:
             smach.StateMachine.add('NAVIGATE_TO_PLACE', NavigateToPlace(robot, place_pose, arm),  # TODO: Navigate to place

--- a/src/robot_smach_states/navigation/navigate_to_explore.py
+++ b/src/robot_smach_states/navigation/navigate_to_explore.py
@@ -5,6 +5,7 @@ from robot_smach_states.navigation import NavigateTo
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
+import ed.msg 
 
 import rospy
 
@@ -18,7 +19,11 @@ class NavigateToExplore(NavigateTo):
         super(NavigateToExplore, self).__init__(robot)
 
         self.robot    = robot
+
+        assert(constraint_designator.resolve_type == ed.msg.EntityInfo) #Check that the constraint designator resolves to an Entity
         self.constraint_designator = constraint_designator
+
+        assert(breakout_designator.resolve_type == ed.msg.EntityInfo) #Check that the constraint designator resolves to an Entity
         self.breakout_designator   = breakout_designator
         self.radius   = radius
         self.exclude_radius = exclude_radius

--- a/src/robot_smach_states/navigation/navigate_to_explore.py
+++ b/src/robot_smach_states/navigation/navigate_to_explore.py
@@ -5,7 +5,9 @@ from robot_smach_states.navigation import NavigateTo
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
-import ed.msg 
+
+from robot_smach_states.util.designators import check_resolve_type
+import ed.msg
 
 import rospy
 
@@ -14,16 +16,16 @@ import rospy
 class NavigateToExplore(NavigateTo):
     def __init__(self, robot, constraint_designator, breakout_designator, radius = .7, exclude_radius = 0.3):
         """@param constraint_designator a Designator that resolves to the entity to explore
-        @param breakout_designator when this Designator successfully resolves, the state signals it is done. 
+        @param breakout_designator when this Designator successfully resolves, the state signals it is done.
                 For example, it could resolve to an item of a class you are looking for."""
         super(NavigateToExplore, self).__init__(robot)
 
         self.robot    = robot
 
-        assert(constraint_designator.resolve_type == ed.msg.EntityInfo) #Check that the constraint designator resolves to an Entity
+        check_resolve_type(constraint_designator, ed.msg.EntityInfo) #Check that the constraint designator resolves to an Entity
         self.constraint_designator = constraint_designator
 
-        assert(breakout_designator.resolve_type == ed.msg.EntityInfo) #Check that the constraint designator resolves to an Entity
+        check_resolve_type(breakout_designator, ed.msg.EntityInfo) #Check that the constraint designator resolves to an Entity
         self.breakout_designator   = breakout_designator
         self.radius   = radius
         self.exclude_radius = exclude_radius
@@ -59,7 +61,7 @@ class NavigateToExplore(NavigateTo):
 
             xs = ch[i].x + (dy/length)*self.radius
             ys = ch[i].y - (dx/length)*self.radius
-            
+
             if i != 0:
                 pci = pci + ' and '
 
@@ -87,7 +89,7 @@ class NavigateToExplore(NavigateTo):
             entity = self.breakout_designator.resolve()
         except:
             return True
-        
+
         rospy.loginfo("Breakout: entity_id = {0}".format(entity.id))
 
         return False

--- a/src/robot_smach_states/navigation/navigate_to_grasp.py
+++ b/src/robot_smach_states/navigation/navigate_to_grasp.py
@@ -6,7 +6,7 @@ from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
 
-from robot_smach_states.util.designators import Designator
+from robot_smach_states.util.designators import Designator, check_resolve_type
 import ed.msg
 from robot_skills.arms import Arm
 
@@ -21,10 +21,10 @@ class NavigateToGrasp(NavigateTo):
         super(NavigateToGrasp, self).__init__(robot)
 
         self.robot    = robot
-        assert(entity_designator.resolve_type == ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
+        check_resolve_type(entity_designator, ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
         self.entity_designator = entity_designator
 
-        assert(arm_designator.resolve_type == Arm) #Check that the arm_designator resolves to an Arm
+        check_resolve_type(arm_designator, Arm) #Check that the arm_designator resolves to an Arm
         self.arm_designator = arm_designator
         if not arm_designator:
             rospy.logerr('NavigateToGrasp: side should be determined by entity_designator. Please specify left or right, will default to left')
@@ -32,7 +32,7 @@ class NavigateToGrasp(NavigateTo):
 
     def generateConstraint(self):
         arm = self.arm_designator.resolve()
-        
+
         if arm == self.robot.arms['left']:
             angle_offset = math.atan2(-self.robot.grasp_offset.y, self.robot.grasp_offset.x)
         elif arm == self.robot.arms['right']:

--- a/src/robot_smach_states/navigation/navigate_to_grasp.py
+++ b/src/robot_smach_states/navigation/navigate_to_grasp.py
@@ -7,6 +7,8 @@ from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
 
 from robot_smach_states.util.designators import Designator
+import ed.msg
+from robot_skills.arms import Arm
 
 import rospy
 
@@ -19,8 +21,10 @@ class NavigateToGrasp(NavigateTo):
         super(NavigateToGrasp, self).__init__(robot)
 
         self.robot    = robot
+        assert(entity_designator.resolve_type == ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
         self.entity_designator = entity_designator
 
+        assert(arm_designator.resolve_type == Arm) #Check that the arm_designator resolves to an Arm
         self.arm_designator = arm_designator
         if not arm_designator:
             rospy.logerr('NavigateToGrasp: side should be determined by entity_designator. Please specify left or right, will default to left')

--- a/src/robot_smach_states/navigation/navigate_to_observe.py
+++ b/src/robot_smach_states/navigation/navigate_to_observe.py
@@ -6,6 +6,8 @@ from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
 
+import ed.msg
+
 import rospy
 
 
@@ -16,6 +18,7 @@ class NavigateToObserve(NavigateTo):
         super(NavigateToObserve, self).__init__(robot)
 
         self.robot    = robot
+        assert(entity_designator.resolve_type == ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
         self.entity_designator = entity_designator
         self.radius   = radius
 

--- a/src/robot_smach_states/navigation/navigate_to_observe.py
+++ b/src/robot_smach_states/navigation/navigate_to_observe.py
@@ -6,6 +6,7 @@ from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
 
+from robot_smach_states.util.designators import check_resolve_type
 import ed.msg
 
 import rospy
@@ -18,7 +19,7 @@ class NavigateToObserve(NavigateTo):
         super(NavigateToObserve, self).__init__(robot)
 
         self.robot    = robot
-        assert(entity_designator.resolve_type == ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
+        check_resolve_type(entity_designator, ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
         self.entity_designator = entity_designator
         self.radius   = radius
 
@@ -39,7 +40,7 @@ class NavigateToObserve(NavigateTo):
         #    return None
 
         x = e.pose.position.x
-        y = e.pose.position.y      
+        y = e.pose.position.y
 
         if len(ch) > 0:
 
@@ -55,7 +56,7 @@ class NavigateToObserve(NavigateTo):
 
                 xs = ch[i].x + (dy/length)*self.radius
                 ys = ch[i].y - (dx/length)*self.radius
-                
+
                 if i != 0:
                     pci = pci + ' and '
 

--- a/src/robot_smach_states/navigation/navigate_to_place.py
+++ b/src/robot_smach_states/navigation/navigate_to_place.py
@@ -6,7 +6,7 @@ from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
 
-from robot_smach_states.util.designators import Designator
+from robot_smach_states.util.designators import Designator, check_resolve_type
 
 import rospy
 
@@ -23,7 +23,7 @@ class NavigateToPlace(NavigateTo):
         super(NavigateToPlace, self).__init__(robot)
 
         self.robot    = robot
-        assert(place_pose_designator.resolve_type == PoseStamped) #Check that place_pose_designator actually returns a PoseStamped
+        check_resolve_type(place_pose_designator, PoseStamped) #Check that place_pose_designator actually returns a PoseStamped
         self.place_pose_designator = place_pose_designator
 
         self.arm_designator = arm_designator
@@ -33,7 +33,7 @@ class NavigateToPlace(NavigateTo):
 
     def generateConstraint(self):
         arm = self.arm_designator.resolve()
-        
+
         x_offset = self.robot.grasp_offset.x
         if arm == self.robot.arms['left']:
             y_offset = self.robot.grasp_offset.y

--- a/src/robot_smach_states/navigation/navigate_to_place.py
+++ b/src/robot_smach_states/navigation/navigate_to_place.py
@@ -23,6 +23,7 @@ class NavigateToPlace(NavigateTo):
         super(NavigateToPlace, self).__init__(robot)
 
         self.robot    = robot
+        assert(place_pose_designator.resolve_type == PoseStamped) #Check that place_pose_designator actually returns a PoseStamped
         self.place_pose_designator = place_pose_designator
 
         self.arm_designator = arm_designator

--- a/src/robot_smach_states/navigation/navigate_to_symbolic.py
+++ b/src/robot_smach_states/navigation/navigate_to_symbolic.py
@@ -5,6 +5,7 @@ from robot_smach_states.navigation import NavigateTo
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
+import ed.msg
 
 import rospy
 
@@ -15,7 +16,12 @@ class NavigateToSymbolic(NavigateTo):
         super(NavigateToSymbolic, self).__init__(robot)
 
         self.robot                 = robot
+        
+        #Check that the entity_designator_area_name_map's keys all resolve to EntityInfo's
+        assert(all(entity_desig.resolve_type == ed.msg.EntityInfo for entity_desig in entity_designator_area_name_map.keys()))
         self.entity_designator_area_name_map     = entity_designator_area_name_map
+
+        assert(entity_lookat_designator.resolve_type == ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
         self.entity_lookat_designator = entity_lookat_designator
 
     def generateConstraint(self):

--- a/src/robot_smach_states/navigation/navigate_to_symbolic.py
+++ b/src/robot_smach_states/navigation/navigate_to_symbolic.py
@@ -5,6 +5,8 @@ from robot_smach_states.navigation import NavigateTo
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
+
+from robot_smach_states.util.designators import check_resolve_type
 import ed.msg
 
 import rospy
@@ -16,12 +18,12 @@ class NavigateToSymbolic(NavigateTo):
         super(NavigateToSymbolic, self).__init__(robot)
 
         self.robot                 = robot
-        
+
         #Check that the entity_designator_area_name_map's keys all resolve to EntityInfo's
         assert(all(entity_desig.resolve_type == ed.msg.EntityInfo for entity_desig in entity_designator_area_name_map.keys()))
         self.entity_designator_area_name_map     = entity_designator_area_name_map
 
-        assert(entity_lookat_designator.resolve_type == ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
+        check_resolve_type(entity_lookat_designator, ed.msg.EntityInfo) #Check that the entity_designator resolves to an Entity
         self.entity_lookat_designator = entity_lookat_designator
 
     def generateConstraint(self):

--- a/src/robot_smach_states/navigation/navigate_to_waypoint.py
+++ b/src/robot_smach_states/navigation/navigate_to_waypoint.py
@@ -5,6 +5,8 @@ from robot_smach_states.navigation import NavigateTo
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
+
+from robot_smach_states.util.designators import check_resolve_type
 import ed.msg
 
 import rospy
@@ -18,7 +20,7 @@ class NavigateToWaypoint(NavigateTo):
 
         self.robot               = robot
 
-        assert(waypoint_designator.resolve_type == ed.msg.EntityInfo) #Check that the waypoint_designator resolves to an Entity
+        check_resolve_type(waypoint_designator, ed.msg.EntityInfo) #Check that the waypoint_designator resolves to an Entity
         self.waypoint_designator = waypoint_designator
         self.radius              = radius
 

--- a/src/robot_smach_states/navigation/navigate_to_waypoint.py
+++ b/src/robot_smach_states/navigation/navigate_to_waypoint.py
@@ -5,6 +5,7 @@ from robot_smach_states.navigation import NavigateTo
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
+import ed.msg
 
 import rospy
 

--- a/src/robot_smach_states/navigation/navigate_to_waypoint.py
+++ b/src/robot_smach_states/navigation/navigate_to_waypoint.py
@@ -16,6 +16,8 @@ class NavigateToWaypoint(NavigateTo):
         super(NavigateToWaypoint, self).__init__(robot)
 
         self.robot               = robot
+
+        assert(waypoint_designator.resolve_type == ed.msg.EntityInfo) #Check that the waypoint_designator resolves to an Entity
         self.waypoint_designator = waypoint_designator
         self.radius              = radius
 

--- a/src/robot_smach_states/util/designators/designator.py
+++ b/src/robot_smach_states/util/designators/designator.py
@@ -53,7 +53,7 @@ class Designator(object):
      ...
     AttributeError: can't set attribute
     
-    >>> assert(d.resolve_type == str)"""
+    >>> assert(issubclass(d.resolve_type, str))"""
 
     def __init__(self, initial_value=None, resolve_type=None):
         super(Designator, self).__init__()
@@ -111,7 +111,7 @@ class VariableDesignator(Designator):
         super(VariableDesignator, self).__init__(initial_value, resolve_type)
 
     def _set_current(self, value):
-        if not type(value) == self.resolve_type:
+        if not issubclass(type(value), self.resolve_type):
             raise TypeError("Assigned value does not match resolve_type for {0}".format(self))
         self._current = value
 
@@ -277,7 +277,7 @@ class AttrDesignator(Designator):
     >>> wrapped.resolve() == 'The most base type'
     True
 
-    >>> assert(wrapped.resolve_type == str)
+    >>> assert(issubclass(wrapped.resolve_type, str))
     """
 
     def __init__(self, orig, attribute, resolve_type=None):
@@ -298,7 +298,7 @@ class FuncDesignator(Designator):
     >>> wrapped.resolve()
     5
 
-    >>> assert(wrapped.resolve_type == int)
+    >>> assert(issubclass(wrapped.resolve_type, int))
     """
 
     def __init__(self, orig, func, resolve_type=None):

--- a/src/robot_smach_states/util/designators/designator.py
+++ b/src/robot_smach_states/util/designators/designator.py
@@ -53,7 +53,7 @@ def check_resolve_type(designator, *allowed_types):
     TypeError: ...
     """
     if not designator.resolve_type in allowed_types:
-        raise TypeError("{0} resolves to {1} but should resolve to {2}".format(designator, designator.resolve_type, allowed_types))
+        raise TypeError("{0} resolves to {1} but should resolve to one of {2}".format(designator, designator.resolve_type, allowed_types))
 
 def check_type(designator_or_value, *allowed_types):
     """

--- a/src/robot_smach_states/util/designators/designator.py
+++ b/src/robot_smach_states/util/designators/designator.py
@@ -88,16 +88,24 @@ class VariableDesignator(Designator):
 
     You can also set current = ...
 
-    >>> v = VariableDesignator()
+    >>> v = VariableDesignator()  # doctest: +IGNORE_EXCEPTION_DETAIL 
+    Traceback (most recent call last):
+      ...
+    TypeError: ...
+
+    >>> v = VariableDesignator(resolve_type=str)
     >>> v.current = 'Works'
     >>> v.current
     'Works'
     """
 
     def __init__(self, initial_value=None, resolve_type=None):
+        if not resolve_type:
+            raise TypeError("VariableDesignator requires to set resolve_type to ensure user can use it")
         super(VariableDesignator, self).__init__(initial_value, resolve_type)
 
     def _set_current(self, value):
+        assert(type(value) == self.resolve_type)
         self._current = value
 
     current = property(Designator._get_current, _set_current)
@@ -110,7 +118,7 @@ class LockingDesignator(Designator):
     A LockingDesignator will resolve to the same object after a call to .lock() and 
     will only resolve to a different value after an unlock() call.
 
-    >>> varying = VariableDesignator(0)
+    >>> varying = VariableDesignator(0, int)
     >>> locking = LockingDesignator(varying)
     >>> assert(varying.resolve() == 0)
     >>> assert(locking.resolve() == 0)
@@ -262,8 +270,7 @@ class AttrDesignator(Designator):
     >>> wrapped.resolve() == 'The most base type'
     True
 
-    >>> wrapped.resolve_type == str
-    True
+    >>> assert(wrapped.resolve_type == str)
     """
 
     def __init__(self, orig, attribute, resolve_type=None):
@@ -280,13 +287,15 @@ class FuncDesignator(Designator):
     """Apply a function to the object a wrapped designator resolves to
     For example:
     >>> d = Designator("Hello")
-    >>> wrapped = FuncDesignator(d, len) #Determine the len of whatever d resolves to
+    >>> wrapped = FuncDesignator(d, len, resolve_type=int) #Determine the len of whatever d resolves to
     >>> wrapped.resolve()
     5
+
+    >>> assert(wrapped.resolve_type == int)
     """
 
-    def __init__(self, orig, func):
-        super(FuncDesignator, self).__init__()
+    def __init__(self, orig, func, resolve_type=None):
+        super(FuncDesignator, self).__init__(resolve_type=resolve_type)
         self.orig = orig
         self.func = func
 

--- a/src/robot_smach_states/util/designators/designator.py
+++ b/src/robot_smach_states/util/designators/designator.py
@@ -94,8 +94,8 @@ class VariableDesignator(Designator):
     'Works'
     """
 
-    def __init__(self, initial_value=None):
-        super(VariableDesignator, self).__init__(initial_value)
+    def __init__(self, initial_value=None, resolve_type=None):
+        super(VariableDesignator, self).__init__(initial_value, resolve_type)
 
     def _set_current(self, value):
         self._current = value
@@ -256,15 +256,18 @@ class AttrDesignator(Designator):
 
     """Get some attribute of the object a wrapped designator resolves to.
     For example:
-    >>> d = Designator(object())
-    >>> #Get the __class__ attribute of the object that d resolves to
-    >>> wrapped = AttrDesignator(d, '__class__')
-    >>> wrapped.resolve() == object
+    >>> d = Designator(object(), resolve_type=object)
+    >>> #Get the __doc__ attribute of the object that d resolves to. d is an object and d.__doc__ is 'The most base type'
+    >>> wrapped = AttrDesignator(d, '__doc__', resolve_type=str)
+    >>> wrapped.resolve() == 'The most base type'
+    True
+
+    >>> wrapped.resolve_type == str
     True
     """
 
-    def __init__(self, orig, attribute):
-        super(AttrDesignator, self).__init__()
+    def __init__(self, orig, attribute, resolve_type=None):
+        super(AttrDesignator, self).__init__(resolve_type=resolve_type)
         self.orig = orig
         self.attribute = attribute
 

--- a/src/robot_smach_states/util/designators/designator.py
+++ b/src/robot_smach_states/util/designators/designator.py
@@ -97,6 +97,12 @@ class VariableDesignator(Designator):
     >>> v.current = 'Works'
     >>> v.current
     'Works'
+
+    >>> v.current = 666  # doctest: +IGNORE_EXCEPTION_DETAIL 
+    Traceback (most recent call last):
+      ...
+    TypeError: ...
+    >>> assert(v.current == 'Works') #Unchanged
     """
 
     def __init__(self, initial_value=None, resolve_type=None):
@@ -105,7 +111,8 @@ class VariableDesignator(Designator):
         super(VariableDesignator, self).__init__(initial_value, resolve_type)
 
     def _set_current(self, value):
-        assert(type(value) == self.resolve_type)
+        if not type(value) == self.resolve_type:
+            raise TypeError("Assigned value does not match resolve_type for {0}".format(self))
         self._current = value
 
     current = property(Designator._get_current, _set_current)


### PR DESCRIPTION
Typechecking for designators enables us to check that the correct types are used when the state machines are constructed. 
A typed language would be better for this sort of stuff but we have Python